### PR TITLE
Update tab size for JS files

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -77,7 +77,7 @@ so ~/.vim/settings.vim
 
 autocmd Filetype html setlocal ts=2 sts=2 sw=2
 autocmd Filetype ruby setlocal ts=2 sts=2 sw=2
-autocmd Filetype javascript setlocal ts=4 sts=4 sw=4
+autocmd Filetype javascript setlocal ts=2 sts=2 sw=2
 
 set wildignore+=*/tmp/*,*.so,*.swp,*.zip,*.class,*/target/*,*/node_modules/*,*/bower_components/*
 set wildignore+=*/dist/*


### PR DESCRIPTION
# Change tab size for JS files from 4 to 2 spaces in vimrc

`autocmd Filetype javascript setlocal ts=2 sts=2 sw=2`